### PR TITLE
✨ Add command `cpac crash crashfile`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Version 0.2.3
 =============
-* ✨ Added ``group`` command
+* ✨ Added ``group`` and ``crash`` commands
 * 🚑 Fixed a bug where pass-through flags were being mangled
 * 🖇️ Binds any directories necessary to access any paths found in pass-through CLI arguments
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest-runner
 pyyaml
 setuptools
 sphinx
-spython
+git+git://github.com/shnizzedy/singularity-cli.git@add/stderr-to-stream
 tabulate >= 0.8.6
 tornado
 websocket-client

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     docker
     docker-pycreds
     pandas >= 0.23.4
-    spython
+    spython @ git+git://github.com/shnizzedy/singularity-cli.git@add/stderr-to-stream#egg=spython
     tabulate >= 0.8.6
     tornado
     websocket-client

--- a/src/cpac/__main__.py
+++ b/src/cpac/__main__.py
@@ -11,6 +11,7 @@ from cpac.backends import Backends
 
 _logger = logging.getLogger(__name__)
 
+# commandline arguments to pass into container after `--`:
 clargs = {'group', 'utils'}
 
 
@@ -98,11 +99,21 @@ def parse_args(args):
     )
 
     parser.add_argument(
-        '-o', '--container_options',
-        dest='container_options',
+        '-o', '--container_option',
+        dest='container_option',
         nargs='+',
         help="parameters and flags to pass through to Docker or Singularity",
         metavar="OPT"
+    )
+    
+    parser.add_argument(
+        '-B', '--custom_binding',
+        dest="custom_binding",
+        nargs="+",
+        help="directory to bind to container with a different path than the "
+             "real path in the format real_path:container_path (eg, "
+             "/home/C-PAC/run5/outputs:/outputs). Use absolute paths for both "
+             "paths"
     )
 
     subparsers = parser.add_subparsers(dest='command')
@@ -153,6 +164,18 @@ def parse_args(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     utils_parser.register('action', 'extend', ExtendAction)
+    
+    crash_parser = subparsers.add_parser(
+        'crash',
+        add_help=True,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    crash_parser.register('action', 'extend', ExtendAction)
+    
+    crash_parser.add_argument(
+        'crashfile',
+        help="path to crashfile"
+    )
 
     parsed, extras = parser.parse_known_args(args)
 
@@ -259,6 +282,11 @@ def main(args):
             **arg_vars
         )
 
+    if args.command == 'crash':
+        Backends(**arg_vars).read_crash(
+            flags=args.extra_args,
+            **arg_vars
+        )
 
 def run():
     main(sys.argv)

--- a/src/cpac/__main__.py
+++ b/src/cpac/__main__.py
@@ -105,7 +105,7 @@ def parse_args(args):
         help="parameters and flags to pass through to Docker or Singularity",
         metavar="OPT"
     )
-    
+
     parser.add_argument(
         '-B', '--custom_binding',
         dest="custom_binding",
@@ -164,14 +164,14 @@ def parse_args(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     utils_parser.register('action', 'extend', ExtendAction)
-    
+
     crash_parser = subparsers.add_parser(
         'crash',
         add_help=True,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     crash_parser.register('action', 'extend', ExtendAction)
-    
+
     crash_parser.add_argument(
         'crashfile',
         help="path to crashfile"
@@ -287,6 +287,7 @@ def main(args):
             flags=args.extra_args,
             **arg_vars
         )
+
 
 def run():
     main(sys.argv)

--- a/src/cpac/backends/docker.py
+++ b/src/cpac/backends/docker.py
@@ -34,9 +34,7 @@ class Docker(Backend):
                         self.docker_kwargs[k] = v
 
     def read_crash(self, crashfile, flags=[], **kwargs):
-        for ckey in ["/wd/", "/crash/", "/log"]:
-            if ckey in crashfile:
-                self._bind_volume(crashfile.split(ckey)[0], '/outputs', 'ro')
+        self._set_crashfile_binding(crashfile)
         self.docker_kwargs['entrypoint'] = f'nipypecli crash {crashfile}'
         self._execute(command=flags)
 
@@ -72,7 +70,7 @@ class Docker(Backend):
         self._execute(**kwargs)
 
     def _execute(self, command, **kwargs):
-        image = ':'.join([
+        self.image = ':'.join([
             kwargs['image'] if kwargs.get(
                 'image'
             ) is not None else 'fcpindi/c-pac',
@@ -81,10 +79,10 @@ class Docker(Backend):
             ) is not None else 'latest'
         ])
 
-        self._load_logging(image)
+        self._load_logging()
 
         self._run = DockerRun(self.client.containers.run(
-            image,
+            self.image,
             command=command,
             detach=True,
             user=':'.join([

--- a/src/cpac/backends/platform.py
+++ b/src/cpac/backends/platform.py
@@ -56,7 +56,9 @@ class Backend(object):
             ), headers='keys', showindex=False),
             '  '
         ))
-        print(f"Logging messages will refer to the {self.platform.name} paths.\n")
+        print(
+            f"Logging messages will refer to the {self.platform.name} paths.\n"
+        )
 
     def _prep_binding(self, binding_path_local, binding_path_remote):
         binding_path_local = os.path.abspath(
@@ -84,8 +86,6 @@ class Backend(object):
             'working_dir',
             os.getcwd()
         )
-
-
         for kwarg in [
             *kwargs.get('extra_args', []), kwargs.get('crashfile', '')
         ]:
@@ -118,9 +118,7 @@ class Backend(object):
                     kwargs[d],
                     'rw' if d == 'output_dir' else 'r'
                 )
-
         uid = os.getuid()
-
         self.bindings = {
             'gid': pwd.getpwuid(uid).pw_gid,
             'mounts': [
@@ -140,8 +138,8 @@ class Backend(object):
             if ckey in crashfile:
                 self._bind_volume(crashfile.split(ckey)[0], '/outputs', 'ro')
 
-class Result(object):
 
+class Result(object):
     mime = None
 
     def __init__(self, name, value):

--- a/src/cpac/backends/platform.py
+++ b/src/cpac/backends/platform.py
@@ -37,7 +37,7 @@ class Backend(object):
         else:
             self.volumes[local] = [b]
 
-    def _load_logging(self, image):
+    def _load_logging(self):
         t = pd.DataFrame([
             (i, j['bind'], j['mode']) for i in self.bindings['volumes'].keys(
             ) for j in self.bindings['volumes'][i]
@@ -45,7 +45,7 @@ class Backend(object):
         t.columns = ['local', self.platform.name, 'mode']
         print(" ".join([
             f"Loading {self.platform.symbol}",
-            image,
+            self.image,
             "with these directory bindings:"
         ]))
         print(textwrap.indent(
@@ -135,6 +135,10 @@ class Backend(object):
             'volumes': self.volumes
         }
 
+    def _set_crashfile_binding(self, crashfile):
+        for ckey in ["/wd/", "/crash/", "/log"]:
+            if ckey in crashfile:
+                self._bind_volume(crashfile.split(ckey)[0], '/outputs', 'ro')
 
 class Result(object):
 

--- a/src/cpac/backends/singularity.py
+++ b/src/cpac/backends/singularity.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from itertools import chain
 from spython.main import Client
@@ -63,30 +62,27 @@ class Singularity(Backend):
 
     def _try_to_stream(self, args, stream_command='run'):
         self._bindings_as_option()
-        if stream_command=='run':
-            for line in Client.run(
-                Client.instance(self.image),
-                args=args,
-                options=self.options,
-                stream=True,
-                return_result=True
-            ):
-                try:
+        try:
+            if stream_command == 'run':
+                for line in Client.run(
+                    Client.instance(self.image),
+                    args=args,
+                    options=self.options,
+                    stream=True,
+                    return_result=True
+                ):
                     yield line
-                except CalledProcessError as e:  # pragma: no cover
-                    print(e)
-        elif stream_command=='execute':
-            for line in Client.execute(
-                self.image,
-                command=args['command'].split(' '),
-                options=self.options,
-                stream=True,
-                quiet=False
-            ):
-                try:
+            elif stream_command == 'execute':
+                for line in Client.execute(
+                    self.image,
+                    command=args['command'].split(' '),
+                    options=self.options,
+                    stream=True,
+                    quiet=False
+                ):
                     yield line
-                except CalledProcessError as e:  # pragma: no cover
-                    print(e)
+        except CalledProcessError:  # pragma: no cover
+            return
 
     def read_crash(self, crashfile, flags=[], **kwargs):
         self._load_logging()

--- a/src/cpac/backends/singularity.py
+++ b/src/cpac/backends/singularity.py
@@ -4,20 +4,21 @@ from itertools import chain
 from spython.main import Client
 from subprocess import CalledProcessError
 
-from cpac.backends.platform import Backend
+from cpac.backends.platform import Backend, Platform_Meta
 
 BINDING_MODES = {'ro': 'ro', 'w': 'rw', 'rw': 'rw'}
 
 
 class Singularity(Backend):
     def __init__(self, **kwargs):
+        self.platform = Platform_Meta('Singularity', 'Ⓢ')
         image = kwargs.get("image")
         tag = kwargs.get("tag")
         pwd = os.getcwd()
         if kwargs.get("working_dir") is not None:
             pwd = kwargs["working_dir"]
             os.chdir(pwd)
-        print("Loading Ⓢ Singularity")
+        print(f"Loading {self.platform.symbol} {self.platform.name}")
         if image and isinstance(image, str) and os.path.exists(image):
             self.image = image
         elif tag and isinstance(tag, str):  # pragma: no cover
@@ -79,11 +80,11 @@ class Singularity(Backend):
             "with these directory bindings:"
         ]))
         print(textwrap.indent(
-            tabulate(t, headers='keys', showindex=False),
+            tabulate(t.applymap(lambda x: textwrap.wrap(x, 42)), headers='keys', showindex=False),
             '  '
         ))
         print("Logging messages will refer to the Singularity paths.")
-        
+
     def _try_to_stream(self, args):
         for line in Client.run(
             self.instance,
@@ -96,6 +97,14 @@ class Singularity(Backend):
                 yield line
             except CalledProcessError as e:  # pragma: no cover
                 print(e)
+
+    def read_crash(self, crashfile, flags=[], **kwargs):
+        raise NotImplementedError("crash not yet implemented for Singularity")
+        # for ckey in ["/wd/", "/crash/", "/log"]:
+        #     if ckey in crashfile:
+        #         self._bind_volume(crashfile.split(ckey)[0], '/outputs', 'ro')
+        # self.docker_kwargs['entrypoint'] = f'nipypecli crash {crashfile}'
+        # self._execute(command=flags)
 
     def run(self, flags=[], **kwargs):
         self._load_logging()

--- a/src/cpac/backends/singularity.py
+++ b/src/cpac/backends/singularity.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 
 from itertools import chain
 from spython.main import Client
@@ -40,7 +41,6 @@ class Singularity(Backend):
                     )
                 except Exception:
                     raise OSError("Could not connect to Singularity")
-        self.instance = Client.instance(self.image)
         self.volumes = {}
         self.options = list(chain.from_iterable(kwargs[
             "container_options"
@@ -61,50 +61,40 @@ class Singularity(Backend):
             ] for local in self.volumes])))]
         )
 
-    def _load_logging(self):
-        import pandas as pd
-        import textwrap
-        from tabulate import tabulate
-
-        t = pd.DataFrame([(
-                i,
-                j['bind'],
-                BINDING_MODES[str(j['mode'])]
-            ) for i in self.bindings['volumes'].keys(
-            ) for j in self.bindings['volumes'][i]
-        ])
-        t.columns = ['local', 'Singularity', 'mode']
-        print(" ".join([
-            "Loading Ⓢ",
-            self.image,
-            "with these directory bindings:"
-        ]))
-        print(textwrap.indent(
-            tabulate(t.applymap(lambda x: textwrap.wrap(x, 42)), headers='keys', showindex=False),
-            '  '
-        ))
-        print("Logging messages will refer to the Singularity paths.")
-
-    def _try_to_stream(self, args):
-        for line in Client.run(
-            self.instance,
-            args=args,
-            options=self.options,
-            stream=True,
-            return_result=True
-        ):
-            try:
-                yield line
-            except CalledProcessError as e:  # pragma: no cover
-                print(e)
+    def _try_to_stream(self, args, stream_command='run'):
+        self._bindings_as_option()
+        if stream_command=='run':
+            for line in Client.run(
+                Client.instance(self.image),
+                args=args,
+                options=self.options,
+                stream=True,
+                return_result=True
+            ):
+                try:
+                    yield line
+                except CalledProcessError as e:  # pragma: no cover
+                    print(e)
+        elif stream_command=='execute':
+            for line in Client.execute(
+                self.image,
+                command=args['command'].split(' '),
+                options=self.options,
+                stream=True,
+                quiet=False
+            ):
+                try:
+                    yield line
+                except CalledProcessError as e:  # pragma: no cover
+                    print(e)
 
     def read_crash(self, crashfile, flags=[], **kwargs):
-        raise NotImplementedError("crash not yet implemented for Singularity")
-        # for ckey in ["/wd/", "/crash/", "/log"]:
-        #     if ckey in crashfile:
-        #         self._bind_volume(crashfile.split(ckey)[0], '/outputs', 'ro')
-        # self.docker_kwargs['entrypoint'] = f'nipypecli crash {crashfile}'
-        # self._execute(command=flags)
+        self._load_logging()
+        self._set_crashfile_binding(crashfile)
+        [print(o, end='') for o in self._try_to_stream(
+            args={'command': f'nipypecli crash {crashfile}'},
+            stream_command='execute'
+        )]
 
     def run(self, flags=[], **kwargs):
         self._load_logging()

--- a/src/cpac/utils.py
+++ b/src/cpac/utils.py
@@ -178,15 +178,15 @@ def ls_newest(directory, extensions):
         return(ls[-1])
     except IndexError:  # pragma: no cover
         return(None)
-        
+
+
 def render_crashfile(crash_path):
     """
     Parameter
     ---------
     crash_path: str
-    
+
     Returns
     -------
     str, contents of pickle
     """
-    

--- a/src/cpac/utils.py
+++ b/src/cpac/utils.py
@@ -178,3 +178,15 @@ def ls_newest(directory, extensions):
         return(ls[-1])
     except IndexError:  # pragma: no cover
         return(None)
+        
+def render_crashfile(crash_path):
+    """
+    Parameter
+    ---------
+    crash_path: str
+    
+    Returns
+    -------
+    str, contents of pickle
+    """
+    

--- a/tests/test_cpac_group.py
+++ b/tests/test_cpac_group.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import sys
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #9 by @shnizzedy

## Description
Adds a `crash` command to the CLI.
```sh
cpac crash crashfile
```
unpickles a C-PAC Nipype crashfile to the terminal.

## Technical details
Also adds a CLI option `-B`/`--custom_binding` `local_path:container_path` that may be necessary if loading a crashfile somewhere other than where it was created (see https://github.com/nipy/nipype/issues/1184) since the classes in the pickles often require the referenced paths to exist.

## Tests
Run
```sh
cpac crash crashfile
```
on a pickle generated by C-PAC.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable). TODO: Create a pickle to test this command.
- [x] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
